### PR TITLE
Add VideoDiaryAPI and associated models for multipart video uploads

### DIFF
--- a/lamp_kotlin/src/main/java/digital/lamp/lamp_kotlin/lamp_core/apis/VideoDiaryAPI.kt
+++ b/lamp_kotlin/src/main/java/digital/lamp/lamp_kotlin/lamp_core/apis/VideoDiaryAPI.kt
@@ -1,0 +1,185 @@
+/**
+ * LAMP Platform
+ * The LAMP Platform API.
+ *
+ * Dedicated API client for participant video diary multipart upload endpoints
+ * (initiate, refresh-urls, complete).
+ */
+package digital.lamp.lamp_kotlin.lamp_core.apis
+
+import android.util.Log
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.ApiClient
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.ClientError
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.ClientException
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.MultiValueMap
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.RequestConfig
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.RequestMethod
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.ResponseType
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.Serializer
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.ServerError
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.ServerException
+import digital.lamp.lamp_kotlin.lamp_core.infrastructure.Success
+import digital.lamp.lamp_kotlin.lamp_core.models.VideoUploadCompleteRequest
+import digital.lamp.lamp_kotlin.lamp_core.models.VideoUploadInitiateRequest
+import digital.lamp.lamp_kotlin.lamp_core.models.VideoUploadRefreshUrlsRequest
+
+class VideoDiaryAPI(basePath: String = defaultBasePath) : ApiClient(basePath) {
+    companion object {
+        private const val TAG = "VideoDiaryAPI"
+
+        @JvmStatic
+        val defaultBasePath: String by lazy {
+            System.getProperties().getProperty("digital.lamp.lamp-core.baseUrl", "https://api.lamp.digital")
+        }
+    }
+
+    /**
+     * Initiate a participant video diary upload.
+     * Initiate upload metadata for a participant video recording.
+     * @param participantId
+     * @param videoUploadInitiateRequest
+     * @param token Optional bearer/basic authorization header value.
+     * @return kotlin.String
+     * @throws UnsupportedOperationException If the API returns an informational or redirection response
+     * @throws ClientException If the API returns a client error response
+     * @throws ServerException If the API returns a server error response
+     */
+    @Suppress("UNCHECKED_CAST")
+    @Throws(UnsupportedOperationException::class, ClientException::class, ServerException::class)
+    fun videoUploadInitiate(
+        participantId: String,
+        videoUploadInitiateRequest: VideoUploadInitiateRequest,
+        token: String? = null
+    ): String {
+        val localVariableBody: Any? = videoUploadInitiateRequest
+        val localVariableQuery: MultiValueMap = mutableMapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf<String, String>()
+            .apply {
+                if (token != null) {
+                    put("authorization", token)
+                }
+            }
+        val localVariableConfig = RequestConfig(
+            RequestMethod.POST,
+            "/participant/{participant_id}/video/upload/initiate"
+                .replace("{" + "participant_id" + "}", "$participantId"),
+            query = localVariableQuery,
+            headers = localVariableHeaders
+        )
+        val localVarResponse = request<String>(
+            localVariableConfig,
+            localVariableBody
+        )
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as String
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+            }
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+            }
+        }
+    }
+
+    /**
+     * Refresh presigned URLs for a participant video diary upload.
+     * Refresh upload URLs for selected multipart upload part numbers.
+     */
+    @Suppress("UNCHECKED_CAST")
+    @Throws(UnsupportedOperationException::class, ClientException::class, ServerException::class)
+    fun videoUploadRefreshUrls(
+        participantId: String,
+        videoUploadRefreshUrlsRequest: VideoUploadRefreshUrlsRequest,
+        token: String? = null
+    ): String {
+        val localVariableBody: Any? = videoUploadRefreshUrlsRequest
+        val localVariableQuery: MultiValueMap = mutableMapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf<String, String>()
+            .apply {
+                if (token != null) {
+                    put("authorization", token)
+                }
+            }
+        val localVariableConfig = RequestConfig(
+            RequestMethod.POST,
+            "/participant/{participant_id}/video/upload/refresh-urls"
+                .replace("{" + "participant_id" + "}", "$participantId"),
+            query = localVariableQuery,
+            headers = localVariableHeaders
+        )
+        val localVarResponse = request<String>(
+            localVariableConfig,
+            localVariableBody
+        )
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as String
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+            }
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+            }
+        }
+    }
+
+    /**
+     * Complete a participant video diary upload.
+     * Complete a multipart video upload after all presigned parts have been uploaded.
+     */
+    @Suppress("UNCHECKED_CAST")
+    @Throws(UnsupportedOperationException::class, ClientException::class, ServerException::class)
+    fun videoUploadComplete(
+        participantId: String,
+        videoUploadCompleteRequest: VideoUploadCompleteRequest,
+        token: String? = null
+    ): String {
+        val localVariableBody: Any? = videoUploadCompleteRequest
+        val localVariableQuery: MultiValueMap = mutableMapOf()
+        val localVariableHeaders: MutableMap<String, String> = mutableMapOf<String, String>()
+            .apply {
+                if (token != null) {
+                    put("authorization", token)
+                }
+            }
+
+        Log.d(
+            TAG,
+            "videoUploadComplete json ${Serializer.moshi.adapter(VideoUploadCompleteRequest::class.java).toJson(videoUploadCompleteRequest)}"
+        )
+        val localVariableConfig = RequestConfig(
+            RequestMethod.POST,
+            "/participant/{participant_id}/video/upload/complete"
+                .replace("{" + "participant_id" + "}", "$participantId"),
+            query = localVariableQuery,
+            headers = localVariableHeaders
+        )
+        val localVarResponse = request<String>(
+            localVariableConfig,
+            localVariableBody
+        )
+
+        return when (localVarResponse.responseType) {
+            ResponseType.Success -> (localVarResponse as Success<*>).data as String
+            ResponseType.Informational -> throw UnsupportedOperationException("Client does not support Informational responses.")
+            ResponseType.Redirection -> throw UnsupportedOperationException("Client does not support Redirection responses.")
+            ResponseType.ClientError -> {
+                val localVarError = localVarResponse as ClientError<*>
+                throw ClientException("Client error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+            }
+            ResponseType.ServerError -> {
+                val localVarError = localVarResponse as ServerError<*>
+                throw ServerException("Server error : ${localVarError.statusCode} ${localVarError.message.orEmpty()}", localVarError.statusCode, localVarResponse)
+            }
+        }
+    }
+}

--- a/lamp_kotlin/src/main/java/digital/lamp/lamp_kotlin/lamp_core/models/VideoUploadInitiateRequest.kt
+++ b/lamp_kotlin/src/main/java/digital/lamp/lamp_kotlin/lamp_core/models/VideoUploadInitiateRequest.kt
@@ -1,0 +1,146 @@
+package digital.lamp.lamp_kotlin.lamp_core.models
+
+import android.os.Parcelable
+import com.squareup.moshi.Json
+import kotlinx.parcelize.Parcelize
+import java.io.Serializable
+
+@Parcelize
+data class VideoUploadInitiateRequest(
+    @Json(name = "participantId")
+    var participantId: String,
+    @Json(name = "metadata")
+    var metadata: VideoUploadMetadata? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadMetadata(
+    @Json(name = "size")
+    var size: Long? = null,
+    @Json(name = "duration")
+    var duration: Double? = null,
+    @Json(name = "codec")
+    var codec: String? = null,
+    @Json(name = "bitrate")
+    var bitrate: Long? = null,
+    @Json(name = "frameRate")
+    var frameRate: kotlin.Int? = null,
+    @Json(name = "height")
+    var height: kotlin.Int? = null,
+    @Json(name = "width")
+    var width: kotlin.Int? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadInitiateResponse(
+    @Json(name = "id")
+    var id: String? = null,
+    @Json(name = "parts")
+    var parts: List<VideoUploadPart>? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadRefreshUrlsRequest(
+    @Json(name = "id")
+    var id: String,
+    @Json(name = "partNumbers")
+    var partNumbers: List<Int>
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadRefreshUrlsResponse(
+    @Json(name = "parts")
+    var parts: List<VideoUploadRefreshedPart>? = null,
+    @Json(name = "expiresAt")
+    var expiresAt: Long? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadRefreshedPart(
+    @Json(name = "partNumber")
+    var partNumber: Int? = null,
+    @Json(name = "startByte")
+    var startByte: Long? = null,
+    @Json(name = "endByte")
+    var endByte: Long? = null,
+    @Json(name = "presignedUrl")
+    var presignedUrl: String? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadPart(
+    @Json(name = "partNumber")
+    var partNumber: Int? = null,
+    @Json(name = "byteRange")
+    var byteRange: VideoUploadByteRange? = null,
+    @Json(name = "method")
+    var method: String? = null,
+    @Json(name = "presignedUrl")
+    var presignedUrl: String? = null,
+    @Json(name = "presignedUrlExpiration")
+    var presignedUrlExpiration: Long? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadByteRange(
+    @Json(name = "start")
+    var start: Long? = null,
+    @Json(name = "end")
+    var end: Long? = null
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadCompleteRequest(
+    @Json(name = "id")
+    var id: String,
+    @Json(name = "parts")
+    var parts: List<VideoUploadCompletedPart>
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}
+
+@Parcelize
+data class VideoUploadCompletedPart(
+    @Json(name = "partNumber")
+    var partNumber: Int,
+    @Json(name = "etag")
+    var etag: String
+) : Serializable, Parcelable {
+    companion object {
+        private const val serialVersionUID: Long = 123
+    }
+}


### PR DESCRIPTION
- Implement `VideoDiaryAPI` with endpoints for initiating, refreshing URLs, and completing participant video diary uploads.
- Add request and response data models for video upload management, including `VideoUploadInitiateRequest`, `VideoUploadRefreshUrlsRequest`, and `VideoUploadCompleteRequest`.
- Support multipart upload metadata such as file size, duration, codec, and byte ranges.